### PR TITLE
Add likes count test on repo update

### DIFF
--- a/src/__tests__/likes.spec.js
+++ b/src/__tests__/likes.spec.js
@@ -33,4 +33,42 @@ describe("Likes", () => {
       .post(`/repositories/123/like`)
       .expect(400);
   });
+
+  it("should not lose current likes when update repository info", async () => {
+    const repository = await request(app)
+      .post("/repositories")
+      .send({
+        url: "https://github.com/Rocketseat/umbriel",
+        title: "Umbriel",
+        techs: ["Node", "Express", "TypeScript"]
+      });
+
+    let response = await request(app).post(
+      `/repositories/${repository.body.id}/like`
+    );
+
+    expect(response.body).toMatchObject({
+      likes: 1
+    });
+
+    response = await request(app).post(
+      `/repositories/${repository.body.id}/like`
+    );
+
+    expect(response.body).toMatchObject({
+      likes: 2
+    });
+
+    response = await request(app)
+      .put(`/repositories/${repository.body.id}`)
+      .send({
+        url: "https://github.com/Rocketseat/unform",
+        title: "Unform",
+        techs: ["React", "ReactNative", "TypeScript", "ContextApi"]
+      });
+
+    expect(response.body).toMatchObject({
+      likes: 2
+    });
+  });
 });


### PR DESCRIPTION
Como mencionado pelo Vinicius Flores em https://github.com/Rocketseat/bootcamp-gostack-desafios/issues/17, os testes não cobrem a regra de negócio referente aos likes não serem perdidos ao atualizar o repositório.