### PR TITLE
Solving deprecation warning of isUuid()

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.17.1",
-    "uuidv4": "^6.0.7"
+    "uuid": "^8.3.0"
   },
   "devDependencies": {
     "jest": "^25.2.6",

--- a/src/__tests__/repositories.spec.js
+++ b/src/__tests__/repositories.spec.js
@@ -1,6 +1,6 @@
 const request = require("supertest");
 const app = require("../app");
-const { isUuid } = require("uuidv4");
+const { validate: isUuid } = require("uuid");
 
 describe("Repositories", () => {
   it("should be able to create a new repository", async () => {

--- a/src/app.js
+++ b/src/app.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const cors = require("cors");
 
-// const { v4: uuid } = require('uuid');
+// const { v4: uuid, validate: isUuid } = require('uuid');
 
 const app = express();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4000,22 +4000,15 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
-  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
-
 uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuidv4@^6.0.7:
-  version "6.0.7"
-  resolved "https://registry.yarnpkg.com/uuidv4/-/uuidv4-6.0.7.tgz#15e920848e1afbbd97b4919bc50f4f2f2278f880"
-  integrity sha512-4mpYRFNqO22EckzxPSJ/+xjn9GgO6SAqEJ33yt23Y+HZZoZOt/6l4U4iIjc86ZfxSN2fSCGGmHNb3kiACFNd1g==
-  dependencies:
-    uuid "7.0.3"
+uuid@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
+  integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
 
 v8-to-istanbul@^4.0.1:
   version "4.1.3"


### PR DESCRIPTION
Ola pessoal. Aqui um aluno da turma 13

O módulo `uuid4` será depreciado em favor do módulo `uuid`. Troquei a dependência para usar o módulo `uuid` e não ter a mensagem 
`DeprecationWarning: isUuid() is deprecated. Use validate() from the uuid module instead.`

Corrigi a sua utilização nos testes e mantive o alias `isUuid` para que tivesse semelhança com o vídeo. 
`const { v4: uuid, validate: isUuid } = require('uuid');`

Espero poder ajudar